### PR TITLE
Fix byte compilation warning (replace-regexp)

### DIFF
--- a/slim-mode.el
+++ b/slim-mode.el
@@ -410,9 +410,8 @@ If N is negative, will remove the spaces instead.  Assumes all
 lines in the region have indentation >= that of the first line."
   (let ((ci (current-indentation)))
     (save-excursion
-      (replace-regexp (concat "^" (make-string ci ? ))
-                      (make-string (max 0 (+ ci n)) ? )
-                      nil (point) (mark)))))
+      (while (re-search-forward (concat "^" (make-string ci ? )) nil t)
+        (replace-match (make-string (max 0 (+ ci n)) ? ) nil nil)))))
 
 (defun slim-electric-backspace (arg)
   "Delete characters or back-dent the current line.


### PR DESCRIPTION
`replace-regexp' used from Lisp code
That command is designed for interactive use only
