### PR TITLE
Fix electric-pair support for 24.4+

### DIFF
--- a/slim-mode.el
+++ b/slim-mode.el
@@ -182,7 +182,7 @@ text nested beneath them.")
 
 (defvar slim-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map [backspace] 'slim-electric-backspace)
+    (define-key map "\177" 'slim-electric-backspace)
     (define-key map "\C-?" 'slim-electric-backspace)
     (define-key map "\C-c\C-f" 'slim-forward-sexp)
     (define-key map "\C-c\C-b" 'slim-backward-sexp)
@@ -431,9 +431,7 @@ the current line."
   (if (or (/= (current-indentation) (current-column))
           (bolp)
           (looking-at "^[ \t]+$"))
-      (if electric-pair-mode
-          (electric-pair-backward-delete-char arg)
-        (backward-delete-char arg))
+      (backward-delete-char-untabify arg)
     (save-excursion
       (let ((ci (current-column)))
         (beginning-of-line)


### PR DESCRIPTION
Shoot, thanks for pulling #14, but since I opened that PR, `electric-pair-mode` has changed under the hood and `(electric-pair-backward-delete-char)` is no longer a defined function.

The good news is electric-pair is more unobtrusive now, so when its activated and you call `(backward-delete-char)` or `(backward-delete-char-untabify)`, it should know what to do.

In addition to removing the call to the undefined method, the solution was to define the lower level backspace key "\177" which is the one that `electric-pair-mode` uses under the hood.
