### PR TITLE
Support implicit do when indenting

### DIFF
--- a/slim-mode.el
+++ b/slim-mode.el
@@ -73,11 +73,7 @@ if the next line could be nested within this line.")
 
 (defvar slim-block-openers
   `("^ *\\([\\.#a-z][^ \t]*\\)\\(\\[.*\\]\\)?"
-    "^ *[-=].*do[ \t]*\\(|.*|[ \t]*\\)?$"
-    ,(concat "^ *-[ \t]*\\("
-             (regexp-opt '("if" "unless" "while" "until" "else"
-                           "begin" "elsif" "rescue" "ensure" "when"))
-             "\\)")
+    "^ *[-=]"
     "^ *|"
     "^ */"
     "^ *[a-z0-9_]:")


### PR DESCRIPTION
In Slim, if control code or output block does not contain `do`, but the next line is indented, it gets implicit do.

From Slim readme:

> The content in the `do` block is then captured automatically and passed to the helper via `yield`. As a syntactic
> sugar you can omit the `do` keyword and write only
> 
> ~~~ slim
> p
>   = headline
>     ' Hello
>     = user.name
> ~~~

This means any _control code_ or _output_ block can have indentation increase after it, regardless if it has `do` or if it has control structures (`if`, `while`, etc).

Changed `slim-block-openers` to support implicit do. As handling of `if`/`unless`/`while`/... is redundant now (they're matched by rule for `-`/`=`), removed it.