### PR TITLE
Fix '==' having separate faces for each '='

### DIFF
--- a/slim-mode.el
+++ b/slim-mode.el
@@ -160,7 +160,7 @@ text nested beneath them.")
          'words) nil nil
            (0 font-lock-keyword-face)))
     ;; tag ==, tag =
-    ("^ *[\\.#a-z0-9_-]+.*[^<>!]\\(==?'?\\) +"
+    ("^ *[\\.#a-z0-9_-]+.*[^<>!=]\\(==?'?\\) +"
      1 font-lock-preprocessor-face)))
 
 (defconst slim-embedded-re "^ *[a-z0-9_-]+:")


### PR DESCRIPTION
`==` symbol after tag was rendered in different faces, first `=` in default face, second `=` in `font-lock-preprocessor-face`.

This was because this rule captured first `=` in its `[^<>!]` part:
https://github.com/slim-template/emacs-slim/blob/3636d18ab1c8b316eea71c4732eb44743e2ded87/slim-mode.el#L162-L164

Added `=` to excluded symbols in this part, now the whole `==` is rendered in `font-lock-preprocessor-face`.

Test file:

```slim
.foo == example
  span == example
.foo = example
  span = example
== example

.foo != example
.foo >= example
.foo <= example
```

[faceup](https://github.com/Lindydancer/faceup) of this file before fix:
```
«t:.foo» =«p:=» example
  «f:span» =«p:=» example
«t:.foo» «p:=» example
  «f:span» = example
«p:==» example

«t:.foo» != example
«t:.foo» >= example
«t:.foo» <= example
```

[faceup](https://github.com/Lindydancer/faceup) of this file after fix:
```
«t:.foo» «p:==» example
  «f:span» «p:==» example
«t:.foo» «p:=» example
  «f:span» = example
«p:==» example

«t:.foo» != example
«t:.foo» >= example
«t:.foo» <= example
```

fixes #17